### PR TITLE
use Microsoft.Build.Construction instead of MvsSln

### DIFF
--- a/DependencyWalker/DependencyWalker.csproj
+++ b/DependencyWalker/DependencyWalker.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="MvsSln" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NuGet.Core" Version="2.14.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />

--- a/DependencyWalker/Extensions.cs
+++ b/DependencyWalker/Extensions.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using DependencyWalker.Model;
+using Microsoft.Build.Evaluation;
 
 [assembly: InternalsVisibleTo("DependencyWalkerTests")]
 namespace DependencyWalker
@@ -124,6 +125,14 @@ namespace DependencyWalker
         {
             public IProjectInSolution Source { get; set; }
             public IProjectDependency Target { get; set; }
+        }
+    }
+
+    internal static class ProjectExtensions
+    {
+        public static string GetProjectName(this Project eProject)
+        {
+            return eProject?.GetPropertyValue("ProjectName");
         }
     }
 }

--- a/DependencyWalker/Properties/launchSettings.json
+++ b/DependencyWalker/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "DependencyWalker": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/DependencyWalker/Walker.cs
+++ b/DependencyWalker/Walker.cs
@@ -23,11 +23,11 @@ using System.Linq;
 using System.Runtime.Caching;
 using System.Threading.Tasks;
 using DependencyWalker.Model;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
-using net.r_eg.MvsSln;
-using net.r_eg.MvsSln.Extensions;
 using NuGet;
 using Serilog;
+using ProjectInSolution = DependencyWalker.Model.ProjectInSolution;
 
 namespace DependencyWalker
 {
@@ -59,12 +59,12 @@ namespace DependencyWalker
 
             List<Project> projects = new List<Project>();
 
-            using (var sln = new Sln(solutionToAnalyse, SlnItems.Projects))
+            var sln = SolutionFile.Parse(solutionToAnalyse);
             {
 
-                foreach (var p in sln.Result.ProjectItems)
+                foreach (var p in sln.ProjectsInOrder.Where(p => p.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat))
                 {
-                    var project = projectCollection.LoadProject(p.fullPath);
+                    var project = projectCollection.LoadProject(p.AbsolutePath);
                     projects.Add(project);
                 }
             }

--- a/DependencyWalkerTests/DependencyWalkerTests.csproj
+++ b/DependencyWalkerTests/DependencyWalkerTests.csproj
@@ -26,12 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="MvsSln">
-      <HintPath>..\..\..\Users\hannah.gray\.nuget\packages\mvssln\2.2.0\lib\net40\MvsSln.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
 

--- a/DependencyWalkerTests/GraphingTests.cs
+++ b/DependencyWalkerTests/GraphingTests.cs
@@ -41,7 +41,7 @@ namespace DependencyWalkerTests
             {
                 PackageRepositories.Add(PackageRepositoryFactory.Default.CreateRepository(uri));
             }
-            var walker = new Walker(@"..\..\..\TestSolution\TestSolution.sln", PackageRepositories, false);  
+            var walker = new Walker(Path.GetFullPath(@"..\..\..\TestSolution\TestSolution.sln"), PackageRepositories, false);  
             walker.Load();
             Tree = walker.Walk();
 

--- a/DependencyWalkerTests/OutputTests.cs
+++ b/DependencyWalkerTests/OutputTests.cs
@@ -39,7 +39,7 @@ namespace DependencyWalkerTests
             {
                 PackageRepositories.Add(PackageRepositoryFactory.Default.CreateRepository(uri));
             }
-            var walker = new Walker(@"..\..\..\TestSolution\TestSolution.sln", PackageRepositories, false);  
+            var walker = new Walker(Path.GetFullPath(@"..\..\..\TestSolution\TestSolution.sln"), PackageRepositories, false);  
             walker.Load();
             Tree = walker.Walk();
 

--- a/DependencyWalkerTests/WalkerTests.cs
+++ b/DependencyWalkerTests/WalkerTests.cs
@@ -35,7 +35,7 @@ namespace DependencyWalkerTests
             {
                 PackageRepositories.Add(PackageRepositoryFactory.Default.CreateRepository(uri));
             }
-            WalkerUnderTest = new Walker(@"..\..\..\TestSolution\TestSolution.sln", PackageRepositories, false);  
+            WalkerUnderTest = new Walker(System.IO.Path.GetFullPath(@"..\..\..\TestSolution\TestSolution.sln"), PackageRepositories, false);  
 
         }
 


### PR DESCRIPTION
I tried to run it on Xero.Reporting.sln but for some reason I got a 'Sequence contains no elements' thrown from inside MsvSln (see screenshot).

![image](https://user-images.githubusercontent.com/1215492/61330919-d71a2b80-a874-11e9-954c-52b2b1e3be08.png)

I noticed you actually don't need MsvSln, you can use out of the box stuff.

So I forked it, tried, and the error disappeared.


~~Unfortunately it breaks the tests because the relative paths to TestSolution.sln don't work anymore.
But, if replaced with an absolute path, the tests pass, so the logic is correct.
Someone needs to find a way to turn those paths into absolute (some GetCurrentPath thing at runtime...)~~