### PR TITLE
Add test log

### DIFF
--- a/DependencyWalker/Walker.cs
+++ b/DependencyWalker/Walker.cs
@@ -97,7 +97,7 @@ namespace DependencyWalker
             );
 
             var masterTree = new SolutionDependencyTree(solutionToAnalyse);
-            masterTree.Projects.AddRange(collection.ToList());
+            masterTree.Projects.AddRange(collection.OrderBy(p => p.Name).ToList());
             return masterTree;
         }
 

--- a/DependencyWalkerTests/OutputTests.cs
+++ b/DependencyWalkerTests/OutputTests.cs
@@ -25,6 +25,7 @@ using Newtonsoft.Json;
 using System.IO;
 using Newtonsoft.Json.Schema;
 using Newtonsoft.Json.Linq;
+using Xunit.Abstractions;
 
 namespace DependencyWalkerTests
 {
@@ -58,10 +59,12 @@ namespace DependencyWalkerTests
     public class OutputTests : IClassFixture<OutputFixture>
     {
         private readonly OutputFixture fixture;
+        private readonly ITestOutputHelper testOutputHelper;
 
-        public OutputTests(OutputFixture fixture)
+        public OutputTests(ITestOutputHelper testOutputHelper, OutputFixture fixture)
         {
             this.fixture = fixture;
+            this.testOutputHelper = testOutputHelper;
         }
 
         [Fact]
@@ -85,6 +88,7 @@ namespace DependencyWalkerTests
         public void DoesNotSerialiseEmptyCollections()
         {
             var tree = JObject.Parse(fixture.SerializedTree);
+            testOutputHelper.WriteLine(tree.ToString());
             var collection = tree["Projects"][0]["NugetDependencyTree"]["Packages"][0]["FoundDependencies"];
             Assert.Null(collection);
             

--- a/DependencyWalkerTests/OutputTests.cs
+++ b/DependencyWalkerTests/OutputTests.cs
@@ -89,9 +89,8 @@ namespace DependencyWalkerTests
         {
             var tree = JObject.Parse(fixture.SerializedTree);
             testOutputHelper.WriteLine(tree.ToString());
-            var collection = tree["Projects"][0]["NugetDependencyTree"]["Packages"][0]["FoundDependencies"];
+            var collection = tree["Projects"][1]["NugetDependencyTree"]["Packages"][0]["FoundDependencies"];
             Assert.Null(collection);
-            
         }
         
         [Fact]


### PR DESCRIPTION
to better understand why the DoesNotSerialiseEmptyCollections might be failing on github actions Example failure is [here](https://github.com/hanzworld/DependencyWalker/actions/runs/6712731519/job/18242884800)