### PR TITLE
Make project ordering deterministic

### DIFF
--- a/DependencyWalker/Walker.cs
+++ b/DependencyWalker/Walker.cs
@@ -97,7 +97,7 @@ namespace DependencyWalker
             );
 
             var masterTree = new SolutionDependencyTree(solutionToAnalyse);
-            masterTree.Projects.AddRange(collection.ToList());
+            masterTree.Projects.AddRange(collection.OrderBy(p => p.Name).ToList());
             return masterTree;
         }
 

--- a/DependencyWalkerTests/OutputTests.cs
+++ b/DependencyWalkerTests/OutputTests.cs
@@ -85,7 +85,7 @@ namespace DependencyWalkerTests
         public void DoesNotSerialiseEmptyCollections()
         {
             var tree = JObject.Parse(fixture.SerializedTree);
-            var collection = tree["Projects"][0]["NugetDependencyTree"]["Packages"][0]["FoundDependencies"];
+            var collection = tree["Projects"][1]["NugetDependencyTree"]["Packages"][0]["FoundDependencies"];
             Assert.Null(collection);
             
         }


### PR DESCRIPTION
by sorting by name. This means runs in different environments should produce more similar graphs. It also fixes the DoesNotSerialiseEmptyCollections which had differences when run locally vs on build server

Investigated in #40 

