### PR TITLE
Use case insentive comparison when matching package reference

### DIFF
--- a/DependencyWalker/NugetDependencyResolution/CSProjFile.cs
+++ b/DependencyWalker/NugetDependencyResolution/CSProjFile.cs
@@ -55,7 +55,7 @@ namespace DependencyWalker.NugetDependencyResolution
 
         private PackageReference CreatePackageReferenceWithPropsFile(ProjectItem packageReference)
         {
-            var item = CmpPackageReferences.FirstOrDefault(reference => reference.Id == packageReference.EvaluatedInclude);
+            var item = CmpPackageReferences.FirstOrDefault(reference => reference.Id.Equals(packageReference.EvaluatedInclude, StringComparison.CurrentCultureIgnoreCase));
             return CreatePackageReference(packageReference.EvaluatedInclude, item.Version);
         }
 


### PR DESCRIPTION
deps to .props file 


nuget packages are techincally case insensitive so this is technically fine for the casing of deps to be mismatched in the csproj compared to the .props file.